### PR TITLE
Fix an edge case on linux

### DIFF
--- a/NutzCode.CloudFileSystem/DirectoryCache/DirectoryCache.cs
+++ b/NutzCode.CloudFileSystem/DirectoryCache/DirectoryCache.cs
@@ -122,6 +122,9 @@ namespace NutzCode.CloudFileSystem.DirectoryCache
                 {
                     if (!originalPath.StartsWith(directory.Name, StringComparison.InvariantCulture)) continue;
 
+                    if (originalPath.Equals(directory.Name, StringComparison.InvariantCulture))
+                        return new FileSystemResult<IObject>(fs);
+
                     lastpart = originalPath.Substring(directory.Name.Length);
                     d = directory;
                 }


### PR DESCRIPTION
This happens, when the folder itself tends to be a mount point.

Ex: /mnt/Anime being a mount point, and the directory being queried, essentially matching the logic of lines 94-95.