### PR TITLE
Fix another linux edge case

### DIFF
--- a/NutzCode.CloudFileSystem/DirectoryCache/DirectoryCache.cs
+++ b/NutzCode.CloudFileSystem/DirectoryCache/DirectoryCache.cs
@@ -123,7 +123,7 @@ namespace NutzCode.CloudFileSystem.DirectoryCache
                     if (!originalPath.StartsWith(directory.Name, StringComparison.InvariantCulture)) continue;
 
                     if (originalPath.Equals(directory.Name, StringComparison.InvariantCulture))
-                        return new FileSystemResult<IObject>(fs);
+                        return new FileSystemResult<IObject>(directory);
 
                     lastpart = originalPath.Substring(directory.Name.Length);
                     d = directory;


### PR DESCRIPTION
This time, if the folder is a scanned folder, it will not populate entries, as the "file system" doesn't have implementations of this.
as the file system is effectively a directory in linux, just returning the directory resolves this issue, making CloudFileSystem treat the information the same way.