### PR TITLE
Only append Seperator Char when needed.

### DIFF
--- a/NutzCode.CloudFileSystem.Plugins.LocalFileSystem/LocalDrive.cs
+++ b/NutzCode.CloudFileSystem.Plugins.LocalFileSystem/LocalDrive.cs
@@ -41,14 +41,20 @@ namespace NutzCode.CloudFileSystem.Plugins.LocalFileSystem
         {
             if (Drive == null)
                 return new DirectoryInfo[0];
-            return Directory.GetDirectories(Name+Path.DirectorySeparatorChar).Select(a=>new DirectoryInfo(a)).ToArray();
+            String path = Name;
+            if (!Name.EndsWith("" + Path.DirectorySeparatorChar))
+                path += Path.DirectorySeparatorChar;
+            return Directory.GetDirectories(path).Select(a=>new DirectoryInfo(a)).ToArray();
         }
 
         public override FileInfo[] GetFiles()
         {
             if (Drive == null)
                 return new FileInfo[0];
-            return Directory.GetFiles(Name+Path.DirectorySeparatorChar).Select(a => new FileInfo(a)).ToArray();
+            String path = Name;
+            if (!Name.EndsWith("" + Path.DirectorySeparatorChar))
+                path += Path.DirectorySeparatorChar;
+            return Directory.GetFiles(path).Select(a => new FileInfo(a)).ToArray();
         }
 
 


### PR DESCRIPTION
This is just a sanity check for linux cases,
`Directory.GetDirectories("//")` throws a UNC error.

example of the exception in question: 

```csharp> Directory.GetDirectories("//")
System.ArgumentException: UNC paths should be of the form \\server\share.
  at System.IO.Path.InsecureGetFullPath (System.String path) [0x0008a] in <>:0
  at System.IO.Path.GetFullPathInternal (System.String path) [0x00000] in <>:0
  at System.IO.FileSystemEnumerableIterator`1[TSource]..ctor (System.String path, System.String originalUserPath, System.String searchPattern, System.IO.SearchOption searchOption, System.IO.SearchResultHandler`1[TSource] resultHandler, System.Boolean checkHost) [0x00038] in <>:0
  at System.IO.FileSystemEnumerableFactory.CreateFileNameIterator (System.String path, System.String originalUserPath, System.String searchPattern, System.Boolean includeFiles, System.Boolean includeDirs, System.IO.SearchOption searchOption, System.Boolean checkHost) [0x00009] in <>:0
  at System.IO.Directory.InternalGetFileDirectoryNames (System.String path, System.String userPathOriginal, System.String searchPattern, System.Boolean includeFiles, System.Boolean includeDirs, System.IO.SearchOption searchOption, System.Boolean checkHost) [0x00000] in <>:0
  at System.IO.Directory.InternalGetDirectories (System.String path, System.String searchPattern, System.IO.SearchOption searchOption) [0x00000] in <>:0
  at System.IO.Directory.GetDirectories (System.String path) [0x0000e] in <>:0
```

